### PR TITLE
Adding path to wad's manually

### DIFF
--- a/src/editor/BspRenderer.cpp
+++ b/src/editor/BspRenderer.cpp
@@ -98,13 +98,10 @@ void BspRenderer::loadTextures() {
 	}
 
 	vector<string> tryPaths = {
-		"./",
-		g_settings.gamedir + "/svencoop/",
-		g_settings.gamedir + "/svencoop_addon/",
-		g_settings.gamedir + "/svencoop_downloads/",
-		g_settings.gamedir + "/svencoop_hd/",
+		"./"
 	};
 
+	tryPaths.insert(tryPaths.end(), g_settings.resPaths.begin(), g_settings.resPaths.end());
 	
 	for (int i = 0; i < wadNames.size(); i++) {
 		string path;

--- a/src/editor/Gui.cpp
+++ b/src/editor/Gui.cpp
@@ -2043,7 +2043,7 @@ void Gui::drawSettings() {
 		const int settings_tabs = 4;
 		static const char* tab_titles[settings_tabs] = {
 			"General",
-			"FGDs",
+			"Paths",
 			"Rendering",
 			"Controls"
 		};
@@ -2071,6 +2071,9 @@ void Gui::drawSettings() {
 		static char fgdPaths[64][256];
 		static int numFgds = 0;
 
+		static char resPaths[64][256];
+		static int numRes = 0;
+
 		if (reloadSettings) {
 			strncpy(gamedir, g_settings.gamedir.c_str(), 256);
 
@@ -2081,6 +2084,15 @@ void Gui::drawSettings() {
 					strncpy(fgdPaths[i], g_settings.fgdPaths[i].c_str(), 256);
 				else
 					strncpy(fgdPaths[i], "", 256);
+			}
+
+			numRes = g_settings.resPaths.size();
+			if (numRes > 64) numRes = 64;
+			for (int i = 0; i < 64; i++) {
+				if (i < numRes)
+					strncpy(resPaths[i], g_settings.resPaths[i].c_str(), 256);
+				else
+					strncpy(resPaths[i], "", 256);
 			}
 
 			reloadSettings = false;
@@ -2122,6 +2134,38 @@ void Gui::drawSettings() {
 				numFgds++;
 				if (numFgds > 64) {
 					numFgds = 64;
+				}
+			}
+
+			ImGui::Separator();
+			ImGui::Text("Resource paths:");
+
+			pathWidth = ImGui::GetWindowWidth() - 60;
+			delWidth = 50;
+			for (int i = 0; i < numRes; i++) {
+				ImGui::SetNextItemWidth(pathWidth);
+				ImGui::InputText(("##res" + to_string(i)).c_str(), resPaths[i], 256);
+				ImGui::SameLine();
+
+				ImGui::SetNextItemWidth(delWidth);
+				ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(0, 0.6f, 0.6f));
+				ImGui::PushStyleColor(ImGuiCol_ButtonHovered, (ImVec4)ImColor::HSV(0, 0.7f, 0.7f));
+				ImGui::PushStyleColor(ImGuiCol_ButtonActive, (ImVec4)ImColor::HSV(0, 0.8f, 0.8f));
+				if (ImGui::Button((" X ##del" + to_string(i)).c_str())) {
+					strncpy(resPaths[i], "", 256);
+					for (int k = i; k < numRes - 1; k++) {
+						memcpy(resPaths[k], resPaths[k + 1], 256);
+					}
+					numRes--;
+				}
+				ImGui::PopStyleColor(3);
+
+			}
+
+			if (ImGui::Button("Add")) {
+				numRes++;
+				if (numRes > 64) {
+					numRes = 64;
 				}
 			}
 		}
@@ -2237,6 +2281,12 @@ void Gui::drawSettings() {
 				for (int i = 0; i < numFgds; i++) {
 					g_settings.fgdPaths.push_back(fgdPaths[i]);
 				}
+
+				g_settings.resPaths.clear();
+				for (int i = 0; i < numRes; i++) {
+					g_settings.resPaths.push_back(resPaths[i]);
+				}
+
 				app->reloadFgdsAndTextures();
 			}
 		}

--- a/src/editor/Renderer.cpp
+++ b/src/editor/Renderer.cpp
@@ -100,6 +100,7 @@ void AppSettings::load() {
 			else if (key == "undo_levels") { g_settings.undoLevels = atoi(val.c_str()); }
 			else if (key == "gamedir") { g_settings.gamedir = val; }
 			else if (key == "fgd") { fgdPaths.push_back(val);  }
+			else if (key == "res") { resPaths.push_back(val); }
 		}
 		g_settings.valid = true;
 
@@ -136,6 +137,10 @@ void AppSettings::save() {
 	file << "gamedir=" << g_settings.gamedir << endl;
 	for (int i = 0; i < fgdPaths.size(); i++) {
 		file << "fgd=" << g_settings.fgdPaths[i] << endl;
+	}
+
+	for (int i = 0; i < resPaths.size(); i++) {
+		file << "res=" << g_settings.resPaths[i] << endl;
 	}
 
 	file << "vsync=" << g_settings.vsync << endl;
@@ -498,13 +503,16 @@ void Renderer::saveSettings() {
 }
 
 void Renderer::loadSettings() {
-	if (!g_settings.valid) {
 
-		if (g_settings.fgdPaths.size() == 0) {
-			g_settings.fgdPaths.push_back(g_settings.gamedir + "/svencoop/sven-coop.fgd");
-		}
+	if (g_settings.fgdPaths.size() == 0) {
+		g_settings.fgdPaths.push_back(g_settings.gamedir + "/svencoop/sven-coop.fgd");
+	}
 
-		return;
+	if (g_settings.resPaths.size() == 0) {
+		g_settings.resPaths.push_back(g_settings.gamedir + "/svencoop/");
+		g_settings.resPaths.push_back(g_settings.gamedir + "/svencoop_addon/");
+		g_settings.resPaths.push_back(g_settings.gamedir + "/svencoop_downloads/");
+		g_settings.resPaths.push_back(g_settings.gamedir + "/svencoop_hd/");
 	}
 
 	gui->showDebugWidget = g_settings.debug_open;

--- a/src/editor/Renderer.h
+++ b/src/editor/Renderer.h
@@ -71,6 +71,7 @@ struct AppSettings {
 	bool show_transform_axes;
 
 	vector<string> fgdPaths;
+	vector<string> resPaths;
 
 	void load();
 	void save();


### PR DESCRIPTION
1. Adding support adding resource paths manually. (Support non svencoop games)
2. Update Paths even if settings is valid(fix crash for added settings)