### PR TITLE
Add CI for automatic building

### DIFF
--- a/.github/build.yml
+++ b/.github/build.yml
@@ -1,0 +1,66 @@
+name: C/C++ CI
+
+on: [push, pull_request]
+
+jobs:
+  build-windows:
+    runs-on: windows-2019
+  
+    steps: 
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Download and install dependencies
+      run: |
+        Invoke-WebRequest https://github.com/ocornut/imgui/archive/refs/tags/v1.81.zip -outfile v1.81.zip
+        Invoke-WebRequest https://github.com/glfw/glfw/releases/download/3.3.3/glfw-3.3.3.zip -outfile glfw-3.3.3.zip
+        Invoke-WebRequest https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0-win32.zip -outfile glew-2.2.0-win32.zip
+
+        tar -xf v1.81.zip
+        tar -xf glfw-3.3.3.zip
+        tar -xf glew-2.2.0-win32.zip
+
+        ren imgui-1.81 imgui
+        ren glfw-3.3.3 glfw
+        ren glew-2.2.0 glew
+
+    - name: Build release 
+      run: |
+        mkdir build && cd build
+        cmake ..
+        cmake --build . --config Release
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: bspguy-windows
+        path: build/Release
+
+  build-linux:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    
+    - name: Download and install dependencies
+      run: |
+        sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libglfw3-dev libglew-dev libxxf86vm-dev
+
+        wget https://github.com/ocornut/imgui/archive/refs/tags/v1.81.zip
+
+        unzip -q v1.81.zip
+
+        mv imgui-1.81 imgui
+
+    - name: Build release
+      run: |
+        mkdir build; cd build
+        cmake .. -DCMAKE_BUILD_TYPE=RELEASE
+        make
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: bspguy-linux
+        path: build/bspguy


### PR DESCRIPTION
Hi, I did this so people can try the newest commits. Basically it builds `bspguy` for Windows and Linux and uploads the artifacts. I haven't added the `scripts` folder inside the artifacts because I don't know in which subfolder goes every file.

I had some building errors with Linux that I have fixed in another pull request #46 .

Note: It also was necessary to install the package `libxxf86vm-dev` for the building in Ubuntu or other way it wouldn't work.