### PR TITLE
Fix Linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ if(MSVC)
 													src/util/lodepng.cpp)
 
 else()
-	target_link_libraries(${PROJECT_NAME} GL GLU X11 Xxf86vm Xrandr pthread Xi GLEW)
+	target_link_libraries(${PROJECT_NAME} GL GLU X11 Xxf86vm Xrandr pthread Xi GLEW stdc++fs)
 	set(CMAKE_CXX_FLAGS "-Wall -std=c++11")
 	set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 	set(CMAKE_CXX_FLAGS_RELEASE "-Os -fno-exceptions -w -Wfatal-errors")

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -719,6 +719,7 @@ bool dirExists(const string& dirName_in)
 #ifndef WIN32
 // mkdir_p for linux from https://gist.github.com/ChisholmKyle/0cbedcd3e64132243a39
 int mkdir_p(const char* dir, const mode_t mode) {
+	const int PATH_MAX_STRING_SIZE = 256;
 	char tmp[PATH_MAX_STRING_SIZE];
 	char* p = NULL;
 	struct stat sb;

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -7,6 +7,7 @@
 #include <string.h>
 #include "Wad.h"
 #include <stdarg.h>
+#include <cfloat>
 #ifdef WIN32
 #include <Windows.h>
 #include <Shlobj.h>


### PR DESCRIPTION
I notice these issues when trying to build for Linux using Github Actions 

Basically, most of the problems were caused by the Windows headers. They are including most stuff than what you expect, generating issues when building for Linux. I fixed by doing this:

- Added missing header <cfloat> when using the definitions FLT_MIN and FLT_MAX.
- Added missing constant PATH_MAX_STRING_SIZE. Probably this was defined in the Windows part by windows.h

And the last issue was a missing library in the CMakeLists that was generating linking issues in the final step of building (stdc++fs).