### PR TITLE
Add build/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ msvc
 /imgui_181
 /msvc_x86
 /fonts
+/build


### PR DESCRIPTION
As per instructions of the repository README and common user choice of having the build folder in the repository directory, Ignore the build/ folder.
