### PR TITLE
Call on Entity::clearEmptyKeyvalues upon saving

### DIFF
--- a/src/bsp/Bsp_ent.cpp
+++ b/src/bsp/Bsp_ent.cpp
@@ -201,9 +201,12 @@ byte* Bsp::create_ent_lump(vector<Entity*>& entList, int& len, bool stripNodes) 
 			}
 		}
 
+		Entity* ent = entList[i];
+		ent->clearEmptyKeyvalues();
+
 		ent_data << "{\n";
 
-		ent_data << entList[i]->getFullKvString();
+		ent_data << ent->getFullKvString();
 
 		ent_data << "}";
 		if (i < entList.size() - 1) {


### PR DESCRIPTION
Aparently BSPGuy keeps empty values. i've been told this didn't happened on previous versions and to be correct keeping them empy will cause problems.

Most level editors (if not all) automatically strips these empty value pairs.

the engine (svengine at least) doesn't check for empty strings when passing them to the games leading to ``pev->model`` being valid but empty which ends with the game setting up a empty model. in worst cases precache error shutting down the server.
